### PR TITLE
Don't create user, if it already exists Create Admin

### DIFF
--- a/lib/tasks/create_admin.rake
+++ b/lib/tasks/create_admin.rake
@@ -21,6 +21,8 @@ namespace :tufts do
     users.push(brian)
 
     users.each do |user|
+      next if User.where(username: user[:username]).present?
+
       u = User.create(
         email: user[:email],
         username: user[:username],


### PR DESCRIPTION
This script could not be run again if it was already run and thus, some of the users had already been create.
This will no longer modify or create a user if one with the same user name exists.

Test this by running `rake tufts:create_admin` twice in a row without seeing any errors.