### PR TITLE
uses an es6 compatible uglifier in stage

### DIFF
--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,8 +48,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  # config.assets.compile = true
-  # config.assets.js_compressor = :uglifier
+
   config.active_job.queue_adapter = :sidekiq
 
   # Configure the drafts strorage directory


### PR DESCRIPTION
We've been using an es6 compatible in prod but never updated stage to match.  Also cleared up a comment in test that was unnecessary while I was there.