### PR TITLE
Rename steward in contributution.rb

### DIFF
--- a/app/models/forms/contribution.rb
+++ b/app/models/forms/contribution.rb
@@ -32,7 +32,7 @@ class Contribution
       visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
       creator: [creator],
       title: [title],
-      steward: 'dca',
+      steward: 'tarc',
       displays_in: ['dl'],
       publisher: ['Tufts University. Digital Collections and Archives.'],
       tufts_license: ['http://dca.tufts.edu/ua/access/rights-creator.html'],

--- a/spec/controllers/contribute_controller_spec.rb
+++ b/spec/controllers/contribute_controller_spec.rb
@@ -117,7 +117,7 @@ describe ContributeController do
                                                   creator: 'John Doe', attachment: uploaded_file }, deposit_type: deposit_type.id }
 
           contribution = Pdf.find(assigns[:contribution].tufts_pdf.id)
-          expect(contribution.steward).to eq 'dca'
+          expect(contribution.steward).to eq 'tarc'
           expect(contribution.displays_in).to eq ['dl']
           expect(contribution.publisher).to eq ['Tufts University. Digital Collections and Archives.']
           expect(contribution.tufts_license).to eq [deposit_type.license_name]


### PR DESCRIPTION
For https://tuftswork.atlassian.net/browse/TDLR-2475. tarc used instead of dca for self deposit.