### PR TITLE
Remove trancript id requirement from index fixing script.

### DIFF
--- a/lib/tufts/transcript_utils.rb
+++ b/lib/tufts/transcript_utils.rb
@@ -35,13 +35,9 @@ module Tufts
 
     def self.conditionally_update_record(id)
       object = ActiveFedora::Base.find(id)
-      if !object.transcript_id.nil?
-        object.update_index
-        object.save
-        Rails.logger.info "updated #{id}"
-      else
-        Rails.logger.info "no transcript #{id}"
-      end
+      object.update_index
+      object.save
+      Rails.logger.info "updated #{id}"
     end
 
     private_class_method :conditionally_update_record, :av_ids, :go_again?


### PR DESCRIPTION
In running the script create in https://github.com/TuftsUniversity/mira_on_hyrax/pull/86 no objects had there indexes changed, because non of them had `transcript_id`s.

an example:
http://tdrsolr-prod-01.it.tufts.edu:8983/solr/mira_prod/select?indent=on&q=f7623t301&wt=json

There were only 1686 responses to the query. So I am removing that condition and running again.