### PR TITLE
Fixing embargo visibility issues

### DIFF
--- a/app/lib/tufts/import_record.rb
+++ b/app/lib/tufts/import_record.rb
@@ -110,12 +110,28 @@ module Tufts
 
     def visibility_during_embargo
       return nil if metadata.nil?
-      metadata.xpath('./tufts:visibility_during_embargo', mapping.namespaces).children.map(&:content).first
+      visibility_during_embargo = metadata.xpath('./tufts:visibility_during_embargo', mapping.namespaces).children.map(&:content).first
+
+      return visibility_during_embargo unless visibility_during_embargo.nil?
+      return nil if visibility_during_embargo.nil? && embargo_release_date.nil?
+
+      # Default to private
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
 
     def visibility_after_embargo
       return nil if metadata.nil?
-      metadata.xpath('./tufts:visibility_after_embargo', mapping.namespaces).children.map(&:content).first
+
+      visibility_after_embargo = metadata.xpath('./tufts:visibility_after_embargo', mapping.namespaces).children.map(&:content).first
+      return visibility_after_embargo unless visibility_after_embargo.nil?
+      return nil if visibility_after_embargo.nil? && embargo_release_date.nil?
+
+      # Should default to inputed visibility
+      visibility = metadata.xpath('./tufts:visibility', mapping.namespaces).first.content
+      return visibility unless visibility.nil?
+
+      # If no info to go off of default public
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     def embargo_release_date

--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -71,6 +71,10 @@ class EmbargoExpirationService
     expirations.each do |expiration|
       Rails.logger.warn "ETD #{expiration.id}: Expiring embargo"
       expiration.visibility = expiration.visibility_after_embargo if expiration.visibility_after_embargo
+      expiration.file_sets.each do |file_set|
+        file_set.visibility = expiration.visibility
+        file_set.save!
+      end
       expiration.deactivate_embargo!
       expiration.embargo.save
       expiration.save

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -21,21 +21,5 @@ FactoryBot.define do
     trait :registered do
       read_groups { ["registered"] }
     end
-
-    trait :with_public_embargo do
-      after(:build) do |file, evaluator|
-        file.embargo = FactoryBot.create(:public_embargo, embargo_release_date: evaluator.embargo_release_date)
-      end
-    end
-
-    factory :file_with_work do
-      after(:build) do |file, _evaluator|
-        file.title = ['testfile']
-      end
-      after(:create) do |file, evaluator|
-        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
-        create(:work, user: evaluator.user).members << file
-      end
-    end
   end
 end

--- a/spec/factories/pdf.rb
+++ b/spec/factories/pdf.rb
@@ -37,4 +37,28 @@ FactoryBot.define do
     corporate_name { [FFaker::Company.name] }
     contributor { [FFaker::Name.name] }
   end
+
+  factory :embargoed_work_with_files, class: Pdf do
+    transient do
+      embargo_date { Date.tomorrow.to_s }
+      current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      user { FactoryBot.create(:user) } # find_or_create ???
+    end
+
+    title { [FFaker::Book.title] }
+    subject { [FFaker::Lorem.word, FFaker::Lorem.word] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    displays_in { ['nowhere'] }
+    rights_statement { ['http://bostonhistory.org/photorequest.html'] }
+    date_created { ['1999'] }
+    publisher { [FFaker::Company.name, FFaker::Company.name] }
+    description { [FFaker::HipsterIpsum.paragraph] }
+    abstract { [FFaker::HipsterIpsum.paragraph] }
+    creator { [FFaker::Name.name, FFaker::Name.name] }
+    corporate_name { [FFaker::Company.name] }
+    contributor { [FFaker::Name.name] }
+    after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, evaluator.current_state, evaluator.future_state) }
+    after(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryBot.create(:file_set, user: evaluator.user) } }
+  end
 end

--- a/spec/fixtures/files/mira_xml_embargo_visibility_test.xml
+++ b/spec/fixtures/files/mira_xml_embargo_visibility_test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+          xmlns:bf2="http://bibframe.org/vocab/"
+          xmlns:bibframe="http://bibframe.org/vocab/"
+          xmlns:dc="http://purl.org/dc/terms/"
+          xmlns:dc11="http://purl.org/dc/elements/1.1/"
+          xmlns:ebucore="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#"
+          xmlns:edm="http://www.europeana.eu/schemas/edm/"
+          xmlns:foaf="http://xmlns.com/foaf/0.1/"
+          xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+          xmlns:marcrelators="http://id.loc.gov/vocabulary/relators/"
+          xmlns:model="info:fedora/fedora-system:def/model#"
+          xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+          xmlns:scholarsphere="http://scholarsphere.psu.edu/ns#"
+          xmlns:terms="http://dl.tufts.edu/terms#"
+          xmlns:tufts="http://dl.tufts.edu/terms#"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <ListRecords>
+      <record>
+         <metadata>
+            <mira_import>
+               <tufts:filename type="representative">Norman_tuftssackler_0845D_10689.pdf</tufts:filename>
+               <dc11:creator>Krobath, Danielle.</dc11:creator>
+               <model:hasModel>Pdf</model:hasModel>
+               <tufts:visibility>open</tufts:visibility>
+               <dc:title>THIS IS A TEST 2</dc:title>
+               <terms:displays_in>nowhere</terms:displays_in>
+               <terms:embargo_release_date>2023-07-11</terms:embargo_release_date>
+            </mira_import>
+         </metadata>
+      </record>
+   </ListRecords>
+</OAI-PMH>

--- a/spec/services/tufts/embargo_expiration_service_spec.rb
+++ b/spec/services/tufts/embargo_expiration_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Tufts::EmbargoExpirationService, :workflow, :clean do
+  let(:record) { FactoryBot.create(:embargoed_work_with_files) }
+  let(:service) { described_class.new(DateTime.now) }
+
+  before do
+    record.embargo_release_date = record.embargo_release_date - 365
+    allow(service).to receive(:find_expirations).and_return([record])
+  end
+
+  it 'expire_embargoes change visbility to public' do
+    expect(record.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    service.expire_embargoes
+
+    expect(record.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
+
+  it 'expire_embargoes change associated files visbility to public' do
+    expect(record.file_sets.first.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    service.expire_embargoes
+
+    expect(record.file_sets.first.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
+end


### PR DESCRIPTION
Fixes bug [TDLR-2423](https://tuftswork.atlassian.net/browse/TDLR-2423)

Fixes issues where objects and associated files ingested didn't change visibility public after embargo expired.