### PR TITLE
Adds Support for Video Transcripts in Generic Objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
       matrix:
         ruby-version: ['2.7.5']
     steps:
+    - name: Pin chrome
+      uses: abhi1693/setup-browser@v0.3.4
+      with:
+        browser: chrome
+        version: 1036826
     - name: Install OS packages
       run: |
         sudo apt-get update

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'okcomputer'
 gem 'pdf-reader'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2'
-gem 'rmagick', '4.2.4'
+gem 'rmagick', '4.2.6'
 
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'omniauth', '1.9.1'
 gem 'omniauth-shibboleth'
 gem 'whenever', require: false
 
-gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.0'
+gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', branch: 'add_transcription_schema' #tag: 'v1.3.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'omniauth', '1.9.1'
 gem 'omniauth-shibboleth'
 gem 'whenever', require: false
 
-gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', branch: 'add_transcription_schema' #tag: 'v1.3.0'
+gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/TuftsUniversity/tufts-curation
-  revision: 89a9db481cc9e9efb68f6966128948b06aaf57a0
-  branch: add_transcription_schema
+  revision: 508861ddb02eed7dc72214a368949fe1021d6303
+  tag: v1.3.1
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -785,7 +785,7 @@ GEM
       railties (>= 5.0)
     retriable (3.1.2)
     rexml (3.2.5)
-    rmagick (4.2.4)
+    rmagick (4.2.6)
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -1026,7 +1026,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rails-controller-testing
   react-rails
-  rmagick (= 4.2.4)
+  rmagick (= 4.2.6)
   rsolr (>= 1.0)
   rspec-rails
   rubyzip (>= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/TuftsUniversity/tufts-curation
-  revision: ff29ef21cb9fe97cf67e4de393e3f0104bf367c6
-  tag: v1.3.0
+  revision: 89a9db481cc9e9efb68f6966128948b06aaf57a0
+  branch: add_transcription_schema
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/app/forms/hyrax/generic_object_form.rb
+++ b/app/forms/hyrax/generic_object_form.rb
@@ -3,7 +3,9 @@
 #  `rails generate hyrax:work GenericObject`
 module Hyrax
   class GenericObjectForm < Hyrax::Forms::WorkForm
+    include Tufts::HasTranscriptForm
     self.model_class = ::GenericObject
+    self.terms += [:transcript_id]
     self.terms += Tufts::Terms.shared_terms
     Tufts::Terms.remove_terms.each { |term| terms.delete(term) }
     self.required_fields = [:title, :displays_in]

--- a/app/forms/tufts/has_transcript_form.rb
+++ b/app/forms/tufts/has_transcript_form.rb
@@ -6,9 +6,9 @@ module Tufts
       Hash[transcript_files.map { |file| [file.to_s, file.id] }]
     end
 
-    def transcript?(file, type)
-      if type == "Video" || type == "Generic Object"
-        ['xml', 'plain', 'vtt'].any? { |type| file.mime_type&.include?(type) }
+    def transcript?(file, object_type)
+      if object_type == "Video" || object_type == "Generic Object"
+        ['xml', 'plain', 'vtt'].any? { |mime_type| file.mime_type&.include?(mime_type) }
       else
         file.mime_type&.include?('xml')
       end

--- a/app/forms/tufts/has_transcript_form.rb
+++ b/app/forms/tufts/has_transcript_form.rb
@@ -7,7 +7,7 @@ module Tufts
     end
 
     def transcript?(file, type)
-      if type == "Video" || type == "GenericObject"
+      if type == "Video" || type == "Generic Object"
         file.mime_type.nil? || file.mime_type.include?('xml') || file.mime_type.include?('plain')
       else
         file.mime_type.nil? || file.mime_type.include?('xml')

--- a/app/forms/tufts/has_transcript_form.rb
+++ b/app/forms/tufts/has_transcript_form.rb
@@ -8,9 +8,9 @@ module Tufts
 
     def transcript?(file, type)
       if type == "Video" || type == "Generic Object"
-        file.mime_type.nil? || file.mime_type.include?('xml') || file.mime_type.include?('plain') || file.mime_type.include?('vtt')
+        ['xml', 'plain', 'vtt'].any? { |type| file.mime_type&.include?(type) }
       else
-        file.mime_type.nil? || file.mime_type.include?('xml')
+        file.mime_type&.include?('xml')
       end
     end
   end

--- a/app/forms/tufts/has_transcript_form.rb
+++ b/app/forms/tufts/has_transcript_form.rb
@@ -8,7 +8,7 @@ module Tufts
 
     def transcript?(file, type)
       if type == "Video" || type == "Generic Object"
-        file.mime_type.nil? || file.mime_type.include?('xml') || file.mime_type.include?('plain')
+        file.mime_type.nil? || file.mime_type.include?('xml') || file.mime_type.include?('plain') || file.mime_type.include?('vtt')
       else
         file.mime_type.nil? || file.mime_type.include?('xml')
       end

--- a/app/forms/tufts/has_transcript_form.rb
+++ b/app/forms/tufts/has_transcript_form.rb
@@ -7,7 +7,7 @@ module Tufts
     end
 
     def transcript?(file, type)
-      if type == "Video"
+      if type == "Video" || type == "GenericObject"
         file.mime_type.nil? || file.mime_type.include?('xml') || file.mime_type.include?('plain')
       else
         file.mime_type.nil? || file.mime_type.include?('xml')

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,7 +1,7 @@
 
 <%= render 'form_media', f: f %>
 
-<% if @curation_concern.class.to_s == 'Audio' || @curation_concern.class.to_s == 'Video' %>
+<% if @curation_concern.class.to_s == 'Audio' || @curation_concern.class.to_s == 'Video' || @curation_concern.class.to_s == 'GenericObject' %>
     <div class="well transcript-selection">
         <%= render_edit_field_partial(:transcript_id, f: f) %>
     </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,12 +84,15 @@ if ENV['IN_DOCKER'].present? || ENV['HUB_URL'].present?
   ip = IPSocket.getaddress(Socket.gethostname)
   Capybara.app_host = "http://#{ip}:#{Capybara.server_port}"
 else
+  Webdrivers::Chromedriver.required_version = '106.0.5249.21'
+  custom_chrome_path = '/opt/hostedtoolcache/chromium/1036826/x64/chrome'
 
   # Adding chromedriver for js testing.
   Capybara.register_driver :selenium_chrome_headless_sandboxless do |app|
     browser_options = ::Selenium::WebDriver::Chrome::Options.new
     browser_options.headless!
     browser_options.args << '--window-size=1920,1080'
+    browser_options.binary = custom_chrome_path
     browser_options.add_preference(:download, prompt_for_download: false, default_directory: DownloadHelpers::PATH.to_s)
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
   end


### PR DESCRIPTION
in support of TDLR-2509:

In cases where the primary object is a video, this causes the video player to be shown in TDL.  There may be multiple supporting files attached in MIRA and in the case one of those files is the video transcript the transcript relationshould should be able to be used to properly associate them.

Also, fixes the pin chromedriver issue we've been seeing everywhere else.
Also, updates rmagick gem, because it'd been on my list to do.