### PR TITLE
ga.yml keeps showing up as untracked, should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ config/handle.yml
 config/pdf_pages.yml
 config/tufts.yml
 config/sidekiq.yml
+config/ga.yml
 # Rubymine
 .idea
 


### PR DESCRIPTION
more of an annoyance than anything, easy enough to cleanup.  surprised we haven't done it sooner.